### PR TITLE
Add support for subdirectory Vigil instance

### DIFF
--- a/lib/vigil_reporter.js
+++ b/lib/vigil_reporter.js
@@ -65,7 +65,8 @@ var VigilReporter = function(options) {
     port    : this.__http_url.port,
 
     path    : (
-      "/reporter/" + encodeURIComponent(this.__options.probe_id) + "/" +
+      this.__http_url.pathname + "/reporter/" +
+        encodeURIComponent(this.__options.probe_id) + "/" +
         encodeURIComponent(this.__options.node_id) + "/"
     ),
 
@@ -83,7 +84,8 @@ var VigilReporter = function(options) {
     port    : this.__http_url.port,
 
     path    : (
-      "/reporter/" + encodeURIComponent(this.__options.probe_id) + "/" +
+      this.__http_url.pathname + "/reporter/" +
+        encodeURIComponent(this.__options.probe_id) + "/" +
         encodeURIComponent(this.__options.node_id) + "/" +
         encodeURIComponent(this.__options.replica_id) + "/"
     ),


### PR DESCRIPTION
This will always prefix post URL with its `pathname` to support Vigil instance in subdirectory like `https://example.com/status/`.